### PR TITLE
Fall back to non-standard header that some servers use to avoid browser popups

### DIFF
--- a/pkg/digest/transport.go
+++ b/pkg/digest/transport.go
@@ -182,6 +182,10 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// accept/reject the challenge
 	wwwAuth := resp.Header.Get("WWW-Authenticate")
+	if wwwAuth == "" {
+		// fall back to non-standard header that some servers use to avoid browser popups
+		wwwAuth = resp.Header.Get("X-WWW-Authenticate")
+	}
 	chal, err := NewChallenge(wwwAuth)
 	if err != nil {
 		return resp, err


### PR DESCRIPTION
The server I'm authenticating with and that I don't control doesn't use the standard `WWW-Authenticate` header, but `X-WWW-Authenticate` instead. Searching on why that is, I found the following sources:

* <https://github.com/pdumais/DumaisLib/blob/master/webserver/HTTPResponse.cpp#L79-L81>
  ```
  // When using a XMLHttpRequest on the client side, sending a 401 with WWW-authenticate
  // will trigger a password prompt on many browser. This might be undesireable if the client
  // side code wants to take care of it. So the hack is to send a X-WWW-authenticate instead
  ```

* <https://github.com/dotnet/aspnetcore/issues/3516>
  ```
  using the IIS built-in Windows Authentication (which uses the X-WWW-Authenticate header under the hood)
  ```

* In general, on `X-` headers: <https://stackoverflow.com/a/3561399> - seems to be a meanwhile deprecated recommendation to prefix non-standard headers this way.

Thus, it would be great to support using `X-WWW-Authenticate` in case `WWW-Authenticate` isn't present.