### PR TITLE
Fix -sess algorithm HA1 formula and lookup

### DIFF
--- a/pkg/digest/credentials.go
+++ b/pkg/digest/credentials.go
@@ -37,9 +37,21 @@ type Credentials struct {
 
 type Hasher func(string) string
 
+// baseAlg returns the algorithm name with any "-sess" suffix stripped
+// and the scheme uppercased, matching the keys in the Algs map.
+func (c *Credentials) baseAlg() string {
+	return strings.TrimSuffix(strings.ToUpper(c.Algorithm), "-SESS")
+}
+
+// isSess reports whether the algorithm uses session-keyed HA1 per
+// RFC 7616 §3.4.2.
+func (c *Credentials) isSess() bool {
+	return strings.HasSuffix(strings.ToUpper(c.Algorithm), "-SESS")
+}
+
 func (c *Credentials) Hasher() Hasher {
+	alg := c.baseAlg()
 	return func(data string) string {
-		alg := strings.ToUpper(strings.TrimSuffix(c.Algorithm, "-sess"))
 		h := Algs[alg]() // create the hash.Hash to avoid sharing
 		h.Reset()
 		fmt.Fprint(h, data)
@@ -51,16 +63,20 @@ func (c *Credentials) kd(secret, data string) string {
 	return fmt.Sprintf("%s:%s", secret, data)
 }
 
-func (c *Credentials) a1() string {
-	var a1 []string
-	a1 = append(a1, c.Username)
-	a1 = append(a1, c.Realm)
-	a1 = append(a1, c.Password)
-	if strings.HasSuffix(c.Algorithm, "-sess") {
-		a1 = append(a1, c.NoncePrime)
-		a1 = append(a1, c.CnoncePrime)
+// ha1 computes the HA1 value per RFC 7616 §3.4.2.
+//
+//	HA1       = H( unq(username) ":" unq(realm) ":" passwd )
+//	HA1-sess  = H( H(unq(username) ":" unq(realm) ":" passwd)
+//	               ":" unq(nonce-prime) ":" unq(cnonce-prime) )
+//
+// The -sess form is a nested hash: H(H(...):nonce-prime:cnonce-prime).
+func (c *Credentials) ha1() string {
+	h := c.Hasher()
+	base := h(strings.Join([]string{c.Username, c.Realm, c.Password}, ":"))
+	if c.isSess() {
+		return h(strings.Join([]string{base, c.NoncePrime, c.CnoncePrime}, ":"))
 	}
-	return strings.Join(a1, ":")
+	return base
 }
 
 func (c *Credentials) a2() string {
@@ -76,7 +92,7 @@ func (c *Credentials) a2() string {
 
 func (c *Credentials) response() (string, error) {
 	h := c.Hasher()
-	ha1 := h(c.a1())
+	ha1 := c.ha1()
 	ha2 := h(c.a2())
 	switch c.Qop {
 	case "auth", "auth-int":
@@ -98,7 +114,7 @@ func (c *Credentials) response() (string, error) {
 }
 
 func (c *Credentials) Authorization() (string, error) {
-	if _, ok := Algs[strings.ToUpper(c.Algorithm)]; !ok {
+	if _, ok := Algs[c.baseAlg()]; !ok {
 		return "", ErrAlgNotImplemented
 	}
 	resp, err := c.response()

--- a/pkg/digest/credentials_test.go
+++ b/pkg/digest/credentials_test.go
@@ -1,6 +1,9 @@
 package digest
 
 import (
+	"crypto/md5"
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -33,6 +36,85 @@ func TestResponse(t *testing.T) {
 		response, err := creds.response()
 		assert.Nil(t, err)
 		assert.Equal(t, resp, response)
+	}
+}
+
+// TestSessHA1Formula verifies that HA1 for -sess variants is computed as
+// the nested hash defined in RFC 7616 §3.4.2:
+//
+//	HA1 = H( H(username:realm:password) : nonce-prime : cnonce-prime )
+//
+// The previous implementation flattened this into a single hash.
+func TestSessHA1Formula(t *testing.T) {
+	const (
+		user  = "Mufasa"
+		pass  = "Circle of Life"
+		realm = "http-auth@example.org"
+		np    = "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v"
+		cp    = "f2/wE4q74E6zIJEtWaHKaf5wv/H5QzzpXusqGemxURZJ"
+	)
+
+	cases := []struct {
+		alg    string
+		hashFn func([]byte) string
+	}{
+		{"MD5-sess", func(b []byte) string { s := md5.Sum(b); return fmt.Sprintf("%x", s) }},
+		{"SHA-256-sess", func(b []byte) string { s := sha256.Sum256(b); return fmt.Sprintf("%x", s) }},
+	}
+
+	for _, tc := range cases {
+		base := tc.hashFn([]byte(user + ":" + realm + ":" + pass))
+		want := tc.hashFn([]byte(base + ":" + np + ":" + cp))
+
+		creds := &Credentials{
+			Username:    user,
+			Password:    pass,
+			Realm:       realm,
+			Algorithm:   tc.alg,
+			NoncePrime:  np,
+			CnoncePrime: cp,
+		}
+		assert.Equal(t, want, creds.ha1(), "alg=%s", tc.alg)
+	}
+}
+
+// TestAuthorizationAcceptsSessAlgs guards against the previous bug where
+// Algs lookup used the raw algorithm token, causing MD5-sess / SHA-256-sess
+// to be rejected with ErrAlgNotImplemented.
+func TestAuthorizationAcceptsSessAlgs(t *testing.T) {
+	for _, alg := range []string{"MD5-sess", "SHA-256-sess", "SHA-512-256-sess"} {
+		creds := &Credentials{
+			Username:    "Mufasa",
+			Password:    "Circle of Life",
+			Realm:       "http-auth@example.org",
+			Algorithm:   alg,
+			Qop:         "auth",
+			Nonce:       "n",
+			NoncePrime:  "n",
+			NonceCount:  1,
+			Cnonce:      "c",
+			CnoncePrime: "c",
+			Method:      "GET",
+			URI:         "/",
+		}
+		_, err := creds.Authorization()
+		assert.Nil(t, err, "alg=%s", alg)
+	}
+}
+
+// TestBaseAlgCaseInsensitive ensures -sess suffix stripping is case-insensitive.
+func TestBaseAlgCaseInsensitive(t *testing.T) {
+	cases := map[string]string{
+		"MD5-sess":     "MD5",
+		"md5-sess":     "MD5",
+		"MD5-SESS":     "MD5",
+		"SHA-256-sess": "SHA-256",
+		"SHA-256":      "SHA-256",
+		"":             "",
+	}
+	for in, want := range cases {
+		got := (&Credentials{Algorithm: in}).baseAlg()
+		assert.Equal(t, want, got, "alg=%q", in)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two correctness bugs were making every `-sess` algorithm variant unusable. This PR fixes both and adds tests.

### C1.a — Algs lookup rejected every `-sess` token
`Authorization()` looked up `Algs[strings.ToUpper(c.Algorithm)]`. `Algs` only holds `MD5`, `SHA-256`, `SHA-512`, `SHA-512-256` — so `MD5-sess`, `SHA-256-sess`, etc. always returned `ErrAlgNotImplemented` before anything was computed.

### C1.b — HA1 formula was wrong for `-sess`
Per RFC 7616 §3.4.2:

```
HA1       = H( unq(username) ":" unq(realm) ":" passwd )
HA1-sess  = H( H(unq(username) ":" unq(realm) ":" passwd)
               ":" unq(nonce-prime) ":" unq(cnonce-prime) )
```

The `-sess` form is a **nested** hash: the inner `H(user:realm:pass)` is hashed first, then combined with `nonce-prime:cnonce-prime` and hashed again. The previous code flattened it to one hash pass over the whole string, producing a different digest. Any server honoring RFC 7616 would have rejected the response.

## Changes

- `pkg/digest/credentials.go`
  - New `baseAlg()` / `isSess()` helpers. `baseAlg` strips `-SESS` case-insensitively.
  - `Authorization()` now validates against `baseAlg()`.
  - New `ha1()` method implements the nested formula.
  - `response()` calls `ha1()` directly instead of going through the old `a1()` → hash path.
  - `Hasher()` reads `baseAlg()` once up front.

No exported surface changes.

## Test plan

- [x] `go test ./...` — existing `TestResponse` / `TestAlgResponse` still pass (non-sess vectors unchanged).
- [x] `TestSessHA1Formula` — recomputes HA1 with `crypto/md5` + `crypto/sha256` directly and asserts `ha1()` matches for MD5-sess and SHA-256-sess.
- [x] `TestAuthorizationAcceptsSessAlgs` — `Authorization()` no longer errors for `MD5-sess`, `SHA-256-sess`, `SHA-512-256-sess`.
- [x] `TestBaseAlgCaseInsensitive` — `MD5-sess`, `md5-sess`, `MD5-SESS` all normalize to `MD5`.
- [x] `go vet ./...` clean, `gofmt -d` clean.

## Part of series

This is PR 1 of 5 from a wider review. Remaining PRs (separate branches) handle:

- PR 2: RoundTrip doesn't mutate caller's request + stale retry + remove shared session state on Transport
- PR 3: Bounded nonce counter (LRU+TTL)
- PR 4: Challenge parser ignores unknown keys; charset/userhash support
- PR 5: API cleanup (NewHTTPClient signature), go.mod bump to 1.22, README fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)