### PR TITLE
Replace nonce counter map with bounded LRU+TTL store

### DIFF
--- a/pkg/digest/nonce.go
+++ b/pkg/digest/nonce.go
@@ -1,0 +1,135 @@
+package digest
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// Defaults for the bounded nonce counter. A long-lived Transport talking to a
+// server that rotates nonces will accumulate one entry per nonce otherwise;
+// these values cap the memory usage without hurting nc accuracy for any
+// nonce the server is actively using.
+const (
+	DefaultNonceCapacity = 1024
+	DefaultNonceTTL      = 30 * time.Minute
+)
+
+// nonceStore is a bounded LRU+TTL counter for the per-nonce request count
+// (nc) used by digest authentication. Entries are evicted when either the
+// capacity is reached (least-recently-seen first) or an entry has gone
+// unused for longer than the TTL.
+type nonceStore struct {
+	mu    sync.Mutex
+	cap   int
+	ttl   time.Duration
+	clock func() time.Time // overridable for testing
+	order *list.List       // front = most recent; each Element holds *nonceEntry
+	m     map[string]*list.Element
+}
+
+type nonceEntry struct {
+	nonce    string
+	nc       int
+	lastSeen time.Time
+}
+
+func newNonceStore(capacity int, ttl time.Duration) *nonceStore {
+	if capacity <= 0 {
+		capacity = DefaultNonceCapacity
+	}
+	if ttl <= 0 {
+		ttl = DefaultNonceTTL
+	}
+	return &nonceStore{
+		cap:   capacity,
+		ttl:   ttl,
+		clock: time.Now,
+		order: list.New(),
+		m:     make(map[string]*list.Element),
+	}
+}
+
+// increment returns the new nc for nonce, allocating an entry if needed.
+func (s *nonceStore) increment(nonce string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.clock()
+	s.sweepExpiredLocked(now)
+
+	if el, ok := s.m[nonce]; ok {
+		e := el.Value.(*nonceEntry)
+		e.nc++
+		e.lastSeen = now
+		s.order.MoveToFront(el)
+		return e.nc
+	}
+
+	if s.order.Len() >= s.cap {
+		s.evictOldestLocked()
+	}
+	e := &nonceEntry{nonce: nonce, nc: 1, lastSeen: now}
+	s.m[nonce] = s.order.PushFront(e)
+	return 1
+}
+
+// reset drops the given nonce from the store. Used when a server responds
+// stale=true and the nonce is known to be unusable.
+func (s *nonceStore) reset(nonce string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if el, ok := s.m[nonce]; ok {
+		s.order.Remove(el)
+		delete(s.m, nonce)
+	}
+}
+
+// size reports the number of live entries.
+func (s *nonceStore) size() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.order.Len()
+}
+
+// count returns the current nc for nonce, or 0 if absent. Does not update
+// recency.
+func (s *nonceStore) count(nonce string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if el, ok := s.m[nonce]; ok {
+		return el.Value.(*nonceEntry).nc
+	}
+	return 0
+}
+
+// sweepExpiredLocked evicts entries older than the TTL. Caller must hold mu.
+// Walks from the back (oldest) forward and stops at the first non-expired
+// entry.
+func (s *nonceStore) sweepExpiredLocked(now time.Time) {
+	cutoff := now.Add(-s.ttl)
+	for {
+		back := s.order.Back()
+		if back == nil {
+			return
+		}
+		e := back.Value.(*nonceEntry)
+		if !e.lastSeen.Before(cutoff) {
+			return
+		}
+		s.order.Remove(back)
+		delete(s.m, e.nonce)
+	}
+}
+
+// evictOldestLocked removes the single least-recently-seen entry. Caller
+// must hold mu.
+func (s *nonceStore) evictOldestLocked() {
+	back := s.order.Back()
+	if back == nil {
+		return
+	}
+	e := back.Value.(*nonceEntry)
+	s.order.Remove(back)
+	delete(s.m, e.nonce)
+}

--- a/pkg/digest/nonce_test.go
+++ b/pkg/digest/nonce_test.go
@@ -1,0 +1,120 @@
+package digest
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNonceStoreIncrementBasic(t *testing.T) {
+	s := newNonceStore(4, time.Hour)
+	assert.Equal(t, 1, s.increment("a"))
+	assert.Equal(t, 2, s.increment("a"))
+	assert.Equal(t, 1, s.increment("b"))
+	assert.Equal(t, 3, s.increment("a"))
+	assert.Equal(t, 2, s.size())
+	assert.Equal(t, 3, s.count("a"))
+	assert.Equal(t, 1, s.count("b"))
+	assert.Equal(t, 0, s.count("missing"))
+}
+
+func TestNonceStoreEvictsOldestWhenFull(t *testing.T) {
+	s := newNonceStore(3, time.Hour)
+	// Drive a manual clock so recency ordering is deterministic.
+	base := time.Unix(0, 0)
+	tick := int64(0)
+	s.clock = func() time.Time {
+		tick++
+		return base.Add(time.Duration(tick) * time.Second)
+	}
+
+	s.increment("a") // tick 1
+	s.increment("b") // tick 2
+	s.increment("c") // tick 3
+	assert.Equal(t, 3, s.size())
+
+	// Touch "a" and "b" so "c" is oldest.
+	s.increment("a") // tick 4
+	s.increment("b") // tick 5
+
+	// Insert "d" — capacity full, "c" must be evicted.
+	s.increment("d") // tick 6
+	assert.Equal(t, 3, s.size())
+	assert.Equal(t, 0, s.count("c"), "oldest entry 'c' should have been evicted")
+	assert.Equal(t, 2, s.count("a"))
+	assert.Equal(t, 2, s.count("b"))
+	assert.Equal(t, 1, s.count("d"))
+}
+
+func TestNonceStoreExpiresByTTL(t *testing.T) {
+	s := newNonceStore(16, 10*time.Second)
+	now := time.Unix(1000, 0)
+	s.clock = func() time.Time { return now }
+
+	s.increment("a")
+	s.increment("b")
+	assert.Equal(t, 2, s.size())
+
+	// Jump past the TTL; next increment should sweep both.
+	now = now.Add(30 * time.Second)
+	s.increment("c")
+	// "a" and "b" were both stale and swept before "c" was added.
+	assert.Equal(t, 1, s.size())
+	assert.Equal(t, 0, s.count("a"))
+	assert.Equal(t, 0, s.count("b"))
+	assert.Equal(t, 1, s.count("c"))
+}
+
+func TestNonceStoreReset(t *testing.T) {
+	s := newNonceStore(4, time.Hour)
+	s.increment("a")
+	s.increment("a")
+	s.increment("a")
+	assert.Equal(t, 3, s.count("a"))
+	s.reset("a")
+	assert.Equal(t, 0, s.count("a"))
+	// Next increment starts fresh.
+	assert.Equal(t, 1, s.increment("a"))
+}
+
+func TestNonceStoreZeroDefaults(t *testing.T) {
+	s := newNonceStore(0, 0)
+	assert.Equal(t, DefaultNonceCapacity, s.cap)
+	assert.Equal(t, DefaultNonceTTL, s.ttl)
+}
+
+// TestTransportNonceStoreConcurrency exercises the thread-safety of the
+// Increment path under heavy concurrent use and asserts the final
+// per-nonce count is exactly the number of writers (no lost updates).
+func TestTransportNonceStoreConcurrency(t *testing.T) {
+	trans := NewTransport("u", "p", nil)
+	const (
+		nonces  = 8
+		workers = 32
+		perKey  = 50
+	)
+	var wg sync.WaitGroup
+	wg.Add(workers * nonces)
+	for w := 0; w < workers; w++ {
+		for n := 0; n < nonces; n++ {
+			key := fmt.Sprintf("nonce-%d", n)
+			go func(k string) {
+				defer wg.Done()
+				for i := 0; i < perKey; i++ {
+					trans.Increment(k)
+				}
+			}(key)
+		}
+	}
+	wg.Wait()
+
+	require.Equal(t, nonces, trans.TrackedNonces())
+	for n := 0; n < nonces; n++ {
+		key := fmt.Sprintf("nonce-%d", n)
+		assert.Equal(t, workers*perKey, trans.NonceCount(key), "key=%s", key)
+	}
+}

--- a/pkg/digest/transport.go
+++ b/pkg/digest/transport.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -60,14 +59,14 @@ type Transport struct {
 	NoncePrime string
 	// CnoncePrime is for session keying 'MD5-sess'
 	CnoncePrime string
-	// NonCounter tracks the count of all nonces we've sent a request for
-	NonceCounter map[string]int
-	// QopPref provides a seem for qop selection
+	// QopPref provides a seam for qop selection
 	QopPref QopPref
-	// Cnoncer provides a seem for cnonce generation
+	// Cnoncer provides a seam for cnonce generation
 	Cnoncer Cnoncer
-	// ncLock mutex's our nonce counter (private and zero init)
-	ncLock sync.Mutex
+
+	// nonces is a bounded LRU+TTL map tracking the nc value for each nonce.
+	// Exposed via Increment / NonceCount / NonceCount.Size.
+	nonces *nonceStore
 }
 
 // NewHTTPClient returns an HTTP client that uses the digest transport.
@@ -84,12 +83,12 @@ func NewTransport(username, password string, transport http.RoundTripper) *Trans
 		transport = DefaultHTTPTransport()
 	}
 	return &Transport{
-		Username:     username,
-		Password:     password,
-		QopPref:      QopFirst,
-		Cnoncer:      Cnoncer16,
-		Transport:    transport,
-		NonceCounter: map[string]int{}, // consider an lru to keep the size of this in check
+		Username:  username,
+		Password:  password,
+		QopPref:   QopFirst,
+		Cnoncer:   Cnoncer16,
+		Transport: transport,
+		nonces:    newNonceStore(DefaultNonceCapacity, DefaultNonceTTL),
 	}
 }
 
@@ -109,16 +108,29 @@ func DefaultHTTPTransport() *http.Transport {
 	}
 }
 
-// Increment tracks the count of the given nonce
+// Increment bumps and returns the nc for the given nonce.
 func (t *Transport) Increment(nonce string) int {
-	t.ncLock.Lock()
-	defer t.ncLock.Unlock()
-	if _, ok := t.NonceCounter[nonce]; !ok {
-		t.NonceCounter[nonce] = 0
+	if t.nonces == nil {
+		t.nonces = newNonceStore(DefaultNonceCapacity, DefaultNonceTTL)
 	}
-	nc := t.NonceCounter[nonce] + 1
-	t.NonceCounter[nonce] = nc
-	return nc
+	return t.nonces.increment(nonce)
+}
+
+// NonceCount returns the current nc for the given nonce, or 0 if the nonce
+// is not tracked. Does not update recency.
+func (t *Transport) NonceCount(nonce string) int {
+	if t.nonces == nil {
+		return 0
+	}
+	return t.nonces.count(nonce)
+}
+
+// TrackedNonces reports the number of nonces currently in the counter.
+func (t *Transport) TrackedNonces() int {
+	if t.nonces == nil {
+		return 0
+	}
+	return t.nonces.size()
 }
 
 // NewCredentials ...

--- a/pkg/digest/transport_test.go
+++ b/pkg/digest/transport_test.go
@@ -13,7 +13,10 @@ func TestNonceCounter(t *testing.T) {
 	assert.Equal(t, 1, trans.Increment("oooh! say it again!"))
 	assert.Equal(t, 2, trans.Increment("mufasaaa!"))
 	assert.Equal(t, 3, trans.Increment("mufasaaa!"))
-	assert.Equal(t, 2, len(trans.NonceCounter))
+	assert.Equal(t, 2, trans.TrackedNonces())
+	assert.Equal(t, 3, trans.NonceCount("mufasaaa!"))
+	assert.Equal(t, 1, trans.NonceCount("oooh! say it again!"))
+	assert.Equal(t, 0, trans.NonceCount("never seen"))
 }
 
 func TestAlgResponse(t *testing.T) {


### PR DESCRIPTION
## Summary

`Transport.NonceCounter` was an unbounded `map[string]int`. A long-lived client talking to a server that rotates nonces (i.e. any server taking digest seriously) accumulates one entry per nonce forever — a slow memory leak. The existing code even had a TODO comment at construction acknowledging this.

This PR replaces it with a bounded LRU+TTL store.

## Design

New internal type in `pkg/digest/nonce.go`:

- **LRU bound**: capacity cap (default **1024**). On overflow, evict the least-recently-seen entry.
- **TTL sweep**: entries unused for **30 min** (default) are swept on any write. Walks from oldest forward and stops at the first non-expired entry, so the sweep cost is proportional to the number of expired entries, not total size.
- **O(1) touch/evict**: `container/list` doubly-linked + `map[string]*list.Element`.
- **Self-contained locking**: the store has its own mutex; `Transport` no longer carries `ncLock`.

## API impact (breaking, bundled into v0.2.0)

- `Transport.NonceCounter map[string]int` — **removed**. Direct access is replaced with methods:
  - `Transport.NonceCount(nonce string) int` — current `nc` for the nonce, or 0 if absent. Does not update recency.
  - `Transport.TrackedNonces() int` — live entry count.
- `Transport.Increment(nonce string) int` — **unchanged signature**, same semantics.

## Changes

- `pkg/digest/nonce.go` — new `nonceStore` + defaults.
- `pkg/digest/transport.go` — wire `Transport` to `nonceStore`; remove `NonceCounter` and `ncLock`; add the two accessor methods.
- `pkg/digest/transport_test.go` — one-line swap: `len(trans.NonceCounter)` → `trans.TrackedNonces()`, plus new `NonceCount` assertions.
- `pkg/digest/nonce_test.go` — new, covers eviction / TTL / reset / concurrency.

## Test plan

- [x] `go test -race ./...` clean.
- [x] `TestNonceStoreEvictsOldestWhenFull` — injected clock ticks per call; drives ordering deterministically, asserts the oldest entry is evicted when a fourth is inserted at cap=3.
- [x] `TestNonceStoreExpiresByTTL` — fixed clock jumps past the TTL; next `increment` sweeps all expired entries.
- [x] `TestNonceStoreReset` — drops a nonce; next `increment` starts at 1.
- [x] `TestNonceStoreZeroDefaults` — zero-valued constructor args fall back to defaults.
- [x] `TestTransportNonceStoreConcurrency` — 32 goroutines × 8 nonces × 50 increments each; asserts exact per-key counts under `-race`.
- [x] `go vet` / `gofmt` clean.

## Part of series

- #8  — `-sess` correctness (C1)
- #9  — RoundTrip rewrite (C2 + I2 + I3)
- **This PR** — bounded nonce counter (I1)
- Up next: challenge parser + charset/userhash (I4+I5); API cleanup + go.mod + README (N1+N2+N3).

Will conflict with #9 in `transport.go` (both touch `Increment` / struct fields). Happy to rebase whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)