### PR TITLE
Tolerant challenge parser + RFC 7616 userhash support

### DIFF
--- a/pkg/digest/challenge.go
+++ b/pkg/digest/challenge.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 )
 
-// Challenge is the digest response www-authenticate header parsed (rfc 7616)
+// Challenge is the parsed form of a Digest WWW-Authenticate challenge
+// (RFC 7616 §3.3).
 type Challenge struct {
 	Scheme    string
 	Realm     string
@@ -15,22 +16,46 @@ type Challenge struct {
 	Stale     string
 	Algorithm string
 	Qop       []string
-	Charset   string
-	Userhash  string
+	// Charset is informational per RFC 7616 §3.4. The only defined value is
+	// "UTF-8"; Go source strings are already UTF-8, so no transcoding is
+	// required on the client side.
+	Charset string
+	// Userhash is "true" when the server has requested that the client hash
+	// the username into the Authorization response. See RFC 7616 §3.4.4.
+	Userhash string
 }
 
-// the regex will only pull (k="v"|k=v)
-var reWwwAuth = regexp.MustCompile(`(\w+\=\".*?\")|(\w+\=[^\,]*)`)
+// UserhashRequested reports whether the challenge asked the client to hash
+// the username in the Authorization header (RFC 7616 §3.4.4).
+func (c *Challenge) UserhashRequested() bool {
+	return strings.EqualFold(c.Userhash, "true")
+}
 
-// NewChallenge parses the www-authenticate header
+// reWwwAuth matches `key="quoted value"` or `key=bareToken` pairs inside a
+// WWW-Authenticate header. It does NOT handle backslash-escaped quotes inside
+// quoted strings — RFC 7616 allows them, but no known digest server emits
+// them in practice, and upgrading to a full RFC 7235 tokenizer is out of
+// scope for this change.
+var reWwwAuth = regexp.MustCompile(`(\w+=\".*?\")|(\w+=[^,]*)`)
+
+// NewChallenge parses a WWW-Authenticate header value into a Challenge.
+//
+// Unknown parameters are silently ignored. RFC 7616 §3.3 says clients MUST
+// ignore any directives they do not understand, and future RFC extensions
+// (or vendor-specific attributes) will include keys this implementation
+// doesn't know about. Returning an error here would make the transport
+// brittle against server-side evolution.
 func NewChallenge(wwwAuth string) (*Challenge, error) {
 	c := &Challenge{}
-	// take everything up to first space (e.g. 'Digest ')
+	// Take the scheme token (everything up to the first space).
 	c.Scheme = strings.SplitN(wwwAuth, " ", 2)[0]
 	const qs = `"`
 	for _, kv := range reWwwAuth.FindAllString(wwwAuth, -1) {
 		parts := strings.SplitN(kv, "=", 2)
-		k, v := strings.ToLower(parts[0]), strings.Trim(parts[1], qs)
+		if len(parts) != 2 {
+			continue
+		}
+		k, v := strings.ToLower(strings.TrimSpace(parts[0])), strings.Trim(parts[1], qs)
 		switch k {
 		case "algorithm":
 			c.Algorithm = v
@@ -41,7 +66,12 @@ func NewChallenge(wwwAuth string) (*Challenge, error) {
 		case "opaque":
 			c.Opaque = v
 		case "qop":
-			c.Qop = strings.Split(v, ",")
+			// trim whitespace around each listed qop
+			qs := strings.Split(v, ",")
+			for i := range qs {
+				qs[i] = strings.TrimSpace(qs[i])
+			}
+			c.Qop = qs
 		case "realm":
 			c.Realm = v
 		case "stale":
@@ -50,8 +80,6 @@ func NewChallenge(wwwAuth string) (*Challenge, error) {
 			c.Charset = v
 		case "userhash":
 			c.Userhash = v
-		default:
-			return nil, ErrBadChallenge
 		}
 	}
 	return c, nil

--- a/pkg/digest/challenge_test.go
+++ b/pkg/digest/challenge_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var rawChallenge = `Digest realm="http-auth@example.org", qop="auth,auth-int", algorithm=SHA-256, nonce="7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", opaque="FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS"`
@@ -18,4 +19,36 @@ func TestParse(t *testing.T) {
 	assert.Equal(t, "FQhe/qaU925kfnzjCev0ciny7QMkPqMAFRtzCUYo5tdS", c.Opaque)
 	assert.Equal(t, "7ypf/xlj9XXwfDPEoM4URrv/xwf94BcCAzFZH4GiTo0v", c.Nonce)
 	assert.Equal(t, "auth-int", c.Qop[1])
+}
+
+// TestParseIgnoresUnknownKeys guards against the previous behavior where any
+// unrecognized parameter caused NewChallenge to return ErrBadChallenge. RFC
+// 7616 §3.3 requires clients to ignore unknown directives.
+func TestParseIgnoresUnknownKeys(t *testing.T) {
+	raw := `Digest realm="r", nonce="n", algorithm=MD5, vendor-ext="ignored", future_flag=1`
+	c, err := NewChallenge(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "r", c.Realm)
+	assert.Equal(t, "n", c.Nonce)
+	assert.Equal(t, "MD5", c.Algorithm)
+}
+
+// TestParseStaleAndUserhash confirms the two RFC 7616 flags are surfaced.
+func TestParseStaleAndUserhash(t *testing.T) {
+	raw := `Digest realm="r", nonce="n", algorithm=SHA-256, stale=true, userhash=true, charset=UTF-8`
+	c, err := NewChallenge(raw)
+	require.NoError(t, err)
+	assert.Equal(t, "true", c.Stale)
+	assert.Equal(t, "true", c.Userhash)
+	assert.Equal(t, "UTF-8", c.Charset)
+	assert.True(t, c.UserhashRequested())
+}
+
+// TestParseQopTrimsWhitespace verifies comma-separated qop lists with
+// surrounding whitespace don't leak spaces into Qop entries.
+func TestParseQopTrimsWhitespace(t *testing.T) {
+	raw := `Digest realm="r", nonce="n", qop="auth, auth-int"`
+	c, err := NewChallenge(raw)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"auth", "auth-int"}, c.Qop)
 }

--- a/pkg/digest/credentials.go
+++ b/pkg/digest/credentials.go
@@ -19,6 +19,10 @@ type Credentials struct {
 	Opaque     string
 	Qop        string // the chosen auth from the server list
 	Algorithm  string // <alg>-sess implies session-keying ()
+	// Userhash mirrors the challenge's userhash=true flag. When set, the
+	// Authorization header emits username=H(unq(username):unq(realm)) and
+	// userhash=true instead of the cleartext username (RFC 7616 §3.4.4).
+	Userhash bool
 
 	// session-keying
 	CnoncePrime string
@@ -102,7 +106,12 @@ func (c *Credentials) Authorization() (string, error) {
 		return "", err
 	}
 	var auth []string
-	auth = append(auth, fmt.Sprintf(`username="%s"`, c.Username))
+	username := c.Username
+	if c.Userhash {
+		h := c.Hasher()
+		username = h(c.Username + ":" + c.Realm)
+	}
+	auth = append(auth, fmt.Sprintf(`username="%s"`, username))
 	auth = append(auth, fmt.Sprintf(`realm="%s"`, c.Realm))
 	auth = append(auth, fmt.Sprintf(`nonce="%s"`, c.Nonce))
 	auth = append(auth, fmt.Sprintf(`uri="%s"`, c.URI))
@@ -117,6 +126,9 @@ func (c *Credentials) Authorization() (string, error) {
 	auth = append(auth, fmt.Sprintf(`response="%s"`, resp))
 	if c.Algorithm != "" {
 		auth = append(auth, fmt.Sprintf(`algorithm=%s`, c.Algorithm))
+	}
+	if c.Userhash {
+		auth = append(auth, `userhash=true`)
 	}
 	return fmt.Sprintf("Digest %s", strings.Join(auth, ", ")), nil
 }

--- a/pkg/digest/credentials_test.go
+++ b/pkg/digest/credentials_test.go
@@ -1,6 +1,7 @@
 package digest
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,4 +34,39 @@ func TestResponse(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, resp, response)
 	}
+}
+
+// TestAuthorizationUserhash verifies that when Userhash is set, the emitted
+// username directive carries H(user:realm) and userhash=true is appended,
+// per RFC 7616 §3.4.4.
+func TestAuthorizationUserhash(t *testing.T) {
+	creds := Credentials{
+		Username:   "Mufasa",
+		Password:   "Circle of Life",
+		Realm:      "http-auth@example.org",
+		Algorithm:  "SHA-256",
+		Nonce:      "n",
+		NonceCount: 1,
+		Cnonce:     "c",
+		Qop:        "auth",
+		Method:     "GET",
+		URI:        "/",
+		Userhash:   true,
+	}
+	auth, err := creds.Authorization()
+	assert.Nil(t, err)
+	assert.NotContains(t, auth, `username="Mufasa"`,
+		"cleartext username must not appear when userhash is set")
+	assert.Contains(t, auth, `userhash=true`,
+		"userhash=true must be advertised in the Authorization header")
+	// The emitted username value should be the 64-char SHA-256 hex of
+	// "Mufasa:http-auth@example.org".
+	assert.Regexp(t, `username="[0-9a-f]{64}"`, auth)
+
+	// And without Userhash, the cleartext form should still be used.
+	creds.Userhash = false
+	auth2, err := creds.Authorization()
+	assert.Nil(t, err)
+	assert.Contains(t, auth2, `username="Mufasa"`)
+	assert.False(t, strings.Contains(auth2, `userhash=true`))
 }

--- a/pkg/digest/transport.go
+++ b/pkg/digest/transport.go
@@ -137,6 +137,7 @@ func (t *Transport) NewCredentials(method, uri, body, cnonce string, c *Challeng
 		Algorithm:   c.Algorithm,
 		Opaque:      c.Opaque,
 		Qop:         t.QopPref(c.Qop),
+		Userhash:    c.UserhashRequested(),
 		NoncePrime:  t.NoncePrime,
 		CnoncePrime: t.CnoncePrime,
 		Nonce:       c.Nonce,


### PR DESCRIPTION
## Summary

Two robustness fixes to the `WWW-Authenticate` parsing and response emission. Part of the review series; independent of #8/#9/#10.

### I4 — Ignore unknown keys

Before: `NewChallenge` returned `ErrBadChallenge` on the first parameter it didn't recognize. RFC 7616 §3.3 requires clients to **ignore** unknown directives. Future RFC extensions or vendor-specific attributes would break every request.

After: the default case in the parser just continues. Also picks up a couple of minor parser robustness fixes (whitespace trimming on keys and qop list entries, defensive skip on malformed kv tokens).

A full RFC 7235 tokenizer rewrite is deliberately out of scope — the regex is noted in comments as not handling backslash-escaped quotes, which isn't something real digest servers emit.

### I5 — `userhash=true` support

When the server advertises `userhash=true` (RFC 7616 §3.4.4), the client must emit `username=H(unq(username):unq(realm))` and the directive `userhash=true`, in place of the cleartext username. The parser already surfaced the flag; nothing consumed it.

## Changes

- `pkg/digest/challenge.go`
  - Default case: continue instead of `return nil, ErrBadChallenge`.
  - Trim whitespace around key and each qop entry.
  - Defensive length check on `SplitN("=", 2)` result.
  - `(c *Challenge) UserhashRequested() bool` helper.
  - Doc-comment for `Charset` — only defined value is UTF-8; Go source strings are UTF-8 so no transcoding on the client side.
- `pkg/digest/credentials.go`
  - New `Userhash bool` field on `Credentials`.
  - `Authorization()` emits the hashed username + `userhash=true` when the flag is set.
- `pkg/digest/transport.go`
  - `NewCredentials` sets `Userhash: c.UserhashRequested()`.

## Test plan

- [x] `go test -race ./...` clean.
- [x] `TestParseIgnoresUnknownKeys` — `vendor-ext=\"ignored\"` and `future_flag=1` don't error.
- [x] `TestParseStaleAndUserhash` — all three fields surface; `UserhashRequested()` returns true.
- [x] `TestParseQopTrimsWhitespace` — `qop=\"auth, auth-int\"` yields `[\"auth\", \"auth-int\"]` without leading spaces.
- [x] `TestAuthorizationUserhash` — emitted username is a 64-char SHA-256 hex (not cleartext) when `Userhash` is set, and cleartext is still emitted when unset.

## Part of series

- #8  — `-sess` correctness (C1)
- #9  — RoundTrip rewrite (C2 + I2 + I3)
- #10 — bounded nonce counter (I1)
- **This PR** — challenge parser + charset/userhash (I4 + I5)
- Up next: API cleanup + go.mod + README (N1+N2+N3).

No conflicts expected with prior PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)