### PR TITLE
Don't authenticate when 401 carries no Digest challenge (fixes #6)

### DIFF
--- a/pkg/digest/roundtrip_test.go
+++ b/pkg/digest/roundtrip_test.go
@@ -177,3 +177,106 @@ func mustGet(t *testing.T, url string) *http.Request {
 	require.NoError(t, err)
 	return req
 }
+
+// TestRoundTripNoDigestChallenge covers issue #6: when a 401 response carries
+// no WWW-Authenticate header (or only non-Digest schemes), the transport must
+// return the 401 to the caller as-is instead of emitting a second request
+// with empty/garbage digest credentials.
+func TestRoundTripNoDigestChallenge(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "no WWW-Authenticate header at all",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+		},
+		{
+			name: "only Basic scheme offered",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("WWW-Authenticate", `Basic realm="secure"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+		},
+		{
+			name: "only Bearer scheme offered",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("WWW-Authenticate", `Bearer realm="api"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&requests, 1)
+				// Guard: if the client attempts a second request it MUST NOT
+				// carry an Authorization header — if it does, the bug is live.
+				if r.Header.Get("Authorization") != "" {
+					t.Errorf("unexpected second request with Authorization=%q", r.Header.Get("Authorization"))
+				}
+				tc.handler(w, r)
+			}))
+			defer srv.Close()
+
+			trans := NewTransport("u", "p", http.DefaultTransport)
+			resp, err := trans.RoundTrip(mustGet(t, srv.URL))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+				"caller must see the original 401")
+			assert.Equal(t, int32(1), atomic.LoadInt32(&requests),
+				"transport must not issue a second request when there is no Digest challenge")
+		})
+	}
+}
+
+// TestRoundTripMultiSchemeChallenge covers the case where the server lists
+// multiple challenges in one WWW-Authenticate header (RFC 7235 §4.1). If any
+// of the offered schemes is Digest, we should still authenticate.
+func TestRoundTripMultiSchemeChallenge(t *testing.T) {
+	srv := &digestServer{
+		challenge: `Basic realm="other", Digest realm="r", qop="auth", algorithm=MD5, nonce="n1"`,
+	}
+	ts := newTestServer(t, srv)
+	defer ts.Close()
+
+	trans := NewTransport("u", "p", http.DefaultTransport)
+	resp, err := trans.RoundTrip(mustGet(t, ts.URL))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, srv.seenAuth, 2)
+	assert.Contains(t, srv.seenAuth[1], "Digest ")
+}
+
+func TestHasDigestScheme(t *testing.T) {
+	cases := []struct {
+		header string
+		want   bool
+	}{
+		{"", false},
+		{`Basic realm="x"`, false},
+		{`Bearer realm="api"`, false},
+		{`Digest realm="r", nonce="n"`, true},
+		{`digest realm="r"`, true}, // case-insensitive
+		{`DIGEST realm="r"`, true}, // all-caps
+		{`Basic realm="x", Digest realm="y"`, true},
+		{`NTLM`, false},
+		{`Digests realm="r"`, false}, // not the scheme token
+		{`XDigest`, false},           // not preceded by start/comma
+	}
+	for _, tc := range cases {
+		h := http.Header{}
+		if tc.header != "" {
+			h.Set("WWW-Authenticate", tc.header)
+		}
+		assert.Equal(t, tc.want, hasDigestScheme(h), "header=%q", tc.header)
+	}
+}

--- a/pkg/digest/transport.go
+++ b/pkg/digest/transport.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -181,6 +182,29 @@ func readChallenge(h http.Header) (*Challenge, error) {
 	return NewChallenge(wwwAuth)
 }
 
+// digestSchemeRE matches the "Digest" auth-scheme token when it appears at
+// the start of a challenge list or after a comma separator (RFC 7235 allows
+// multiple challenges in one header, e.g. `Basic realm="x", Digest realm="y"`).
+var digestSchemeRE = regexp.MustCompile(`(?i)(?:^|,)\s*Digest(?:\s|$)`)
+
+// hasDigestScheme reports whether any WWW-Authenticate (or X-WWW-Authenticate
+// fallback) header value actually advertises the Digest scheme. Servers that
+// return 401 without a WWW-Authenticate header at all, or that offer only
+// non-Digest schemes (Basic, Bearer, NTLM), leave nothing for this transport
+// to answer.
+func hasDigestScheme(h http.Header) bool {
+	values := h.Values("WWW-Authenticate")
+	if len(values) == 0 {
+		values = h.Values("X-WWW-Authenticate")
+	}
+	for _, v := range values {
+		if digestSchemeRE.MatchString(v) {
+			return true
+		}
+	}
+	return false
+}
+
 // RoundTrip implements http.RoundTripper. It issues the request; on a 401 it
 // parses the challenge, constructs digest credentials, and retries with an
 // Authorization header. Retries once more if the server returns stale=true.
@@ -225,6 +249,13 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, bodyBytes, err := attempt("")
 	if err != nil || resp.StatusCode != http.StatusUnauthorized {
 		return resp, err
+	}
+
+	// A 401 without a Digest challenge is not ours to answer. Return the
+	// response to the caller unchanged rather than emitting a second
+	// request with empty/garbage credentials (fixes #6).
+	if !hasDigestScheme(resp.Header) {
+		return resp, nil
 	}
 
 	// Authenticated attempts (initial + optional stale retry).


### PR DESCRIPTION
## Summary

Fixes #6 (reported by @andig from [evcc-io/evcc](https://github.com/evcc-io/evcc)).

### The bug

A server returned 401 without a `WWW-Authenticate` header. The client continued the auth flow anyway, emitting a second request with `Authorization: Digest username="...", realm="", nonce="", nc=00000001, ...` — built from an empty challenge.

Root cause: `NewChallenge("")` returns `&Challenge{}` with `err == nil`. `RoundTrip` never checked whether the 401 actually carried a Digest challenge, so **any** 401 triggered a follow-up request with garbage credentials — including 401s that only offered Basic, Bearer, or NTLM.

### Fix

After the first 401, call `hasDigestScheme(resp.Header)`. If no `WWW-Authenticate` (or `X-WWW-Authenticate` fallback) value advertises the Digest scheme, return the 401 to the caller unchanged. There's nothing for this transport to answer.

`hasDigestScheme` uses a token-boundary regex so it correctly handles:
- a single Digest challenge, or a leading Digest token
- multi-scheme challenges per RFC 7235 §4.1 (e.g. `Basic realm="x", Digest realm="y"`)
- case variants (`Digest` / `digest` / `DIGEST`)
- does NOT match substrings like `Digests` or `XDigest`

## Changes

- `pkg/digest/transport.go`
  - New `hasDigestScheme(h http.Header) bool` helper + `digestSchemeRE`.
  - `RoundTrip` short-circuits to the 401 when no Digest challenge is advertised.

## Test plan

- [x] `go test -race ./...` clean.
- [x] `TestRoundTripNoDigestChallenge` — three subcases (no header, Basic-only, Bearer-only). Server handler asserts no second request arrives with `Authorization` set.
- [x] `TestRoundTripMultiSchemeChallenge` — `Basic realm="other", Digest realm="r", ...` still reaches 200 via Digest auth.
- [x] `TestHasDigestScheme` — table-driven, including case variants and negative cases.
- [x] All pre-existing tests still pass (no behavior change for real Digest 401s).

Closes #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)